### PR TITLE
Minor update

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,3 @@
-provider "aws" {
-  region = var.region
-}
-
 module "std" {
   source =  "github.com/clearscale/tf-standards.git?ref=v1.0.0"
 


### PR DESCRIPTION
Removing provider config from module since this denotes a legacy module.

`
│ Error: Module is incompatible with count, for_each, and depends_on
│
│   on kms.tf line 4, in module "kms":
│    4:   count   = 0
│
│ The module at module.ecr.module.kms is a legacy module which contains its own local provider configurations, and so
│ calls to it may not use the count, for_each, or depends_on arguments.
│
│ If you also control the module "../tf-aws-kms", consider updating this module to instead expect provider
│ configurations to be passed by its caller.
╵
`